### PR TITLE
Add py_partiql_parser to packages list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ dependencies = []
 
 [tool.setuptools]
 packages = [
+    "py_partiql_parser",
+    "py_partiql_parser._internal",
     "tests"
 ]
 


### PR DESCRIPTION
setuptools traverses the packages list when deciding what to populate the sdist and wheels with, and as it stands, only the tests are shipped in them. Include both py_partiql_parser and the _internal module, so they are shipped as well.