### PR TITLE
Improve Update/Delete/Insert parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 CHANGELOG
 =========
 
+0.5.1
+-----
+
+ - Support INSERT/DELETE/UPDATE queries:
+
+   - that contain a table name without quotes
+   - that contain parameters
+   - when calling get_query_metadata()
+
+
 0.5.0
 -----
  - Improved typing support

--- a/py_partiql_parser/__init__.py
+++ b/py_partiql_parser/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 
 from ._internal.parser import DynamoDBStatementParser, S3SelectParser  # noqa

--- a/py_partiql_parser/_internal/delete_parser.py
+++ b/py_partiql_parser/_internal/delete_parser.py
@@ -48,6 +48,11 @@ class DeleteParser:
                     assert current_phrase.upper() == "AND"
                     section = "WHERE"
                     current_phrase = ""
+                if section == "TABLE_NAME":
+                    table_name = current_phrase
+                    current_phrase = ""
+                    tokenizer.skip_white_space()
+                    section = "SECTION_WHERE"
                 continue
             elif c in ["'", '"']:
                 if section == "TABLE_NAME":

--- a/py_partiql_parser/_internal/insert_parser.py
+++ b/py_partiql_parser/_internal/insert_parser.py
@@ -41,6 +41,11 @@ class InsertParser:
                     attr = JsonParser().parse(tokenizer.give_remaining())
                     for key, value in attr.items():
                         attr[key] = serializer.serialize(value)
+                if section == "TABLE_NAME":
+                    table_name = current_phrase
+                    current_phrase = ""
+                    tokenizer.skip_white_space()
+                    section = "SECTION_VALUE"
                 continue
             elif c in ["'", '"']:
                 if section == "TABLE_NAME":

--- a/py_partiql_parser/_internal/update_parser.py
+++ b/py_partiql_parser/_internal/update_parser.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Optional
+from typing import Any, List, Tuple
 
 from .clause_tokenizer import ClauseTokenizer
 from .utils import serializer
@@ -7,19 +7,15 @@ from .utils import serializer
 class UpdateParser:
     def parse(
         self, query: str
-    ) -> Tuple[
-        str,
-        List[Tuple[str, Optional[Dict[str, Any]]]],
-        List[Tuple[str, Dict[str, Any]]],
-    ]:
+    ) -> Tuple[str, List[Tuple[str, Any]], List[Tuple[str, Any]]]:
         tokenizer = ClauseTokenizer(query)
 
         section = "START"
         current_phrase = ""
 
         table_name = ""
-        attrs_to_update: List[Tuple[str, Optional[Dict[str, Any]]]] = []
-        attr_filters = []
+        attrs_to_update: List[Tuple[str, Any]] = []
+        attr_filters: List[Tuple[str, Any]] = []
 
         while True:
             c = tokenizer.next()
@@ -33,6 +29,7 @@ class UpdateParser:
                     ), f"{current_phrase} should be UPDATE"
                     current_phrase = ""
                     section = "TABLE_NAME"
+                    continue
                 if section == "ACTION":
                     assert current_phrase.upper() in ["SET", "REMOVE"]
                     section = f"ACTION_{current_phrase.upper()}"
@@ -42,6 +39,7 @@ class UpdateParser:
                     assert current_phrase.upper() == "WHERE"
                     section = "WHERE"
                     current_phrase = ""
+                    continue
                 if section == "WHERE_AND":
                     assert current_phrase.upper() == "AND"
                     section = "WHERE"
@@ -54,38 +52,64 @@ class UpdateParser:
 
                     tokenizer.skip_white_space()
                     section = "SECTION_WHERE"
+                if section == "TABLE_NAME":
+                    table_name = current_phrase
+                    current_phrase = ""
+                    tokenizer.skip_white_space()
+                    section = "ACTION"
                 continue
             elif c in ["'", '"']:
                 if section == "TABLE_NAME":
                     table_name = tokenizer.next_until([c])
                     tokenizer.skip_white_space()
                     section = "ACTION"
+                if section == "ACTION_SET":
+                    current_phrase = tokenizer.next_until([c])
+                    tokenizer.skip_white_space()
+                if section == "WHERE":
+                    current_phrase = tokenizer.next_until([c])
+                    tokenizer.skip_white_space()
                 continue
             elif c == "=":
                 if section == "ACTION_SET":
                     attr_name = current_phrase
                     tokenizer.skip_white_space()
-                    quote_type = tokenizer.current()
-                    assert quote_type in ["'", '"']
+                    if tokenizer.current() == "?":
+                        attrs_to_update.append((attr_name, "?"))
+                        tokenizer.next_until(["?"])
+                    else:
+                        quote_type = tokenizer.current()
+                        assert quote_type in ["'", '"', "?"]
 
-                    tokenizer.next()
-                    attr_value = tokenizer.next_until([quote_type])
-                    attrs_to_update.append(
-                        (attr_name, serializer.serialize(attr_value))
-                    )
+                        tokenizer.next()
+                        attr_value = tokenizer.next_until([quote_type])
+                        attrs_to_update.append(
+                            (attr_name, serializer.serialize(attr_value))
+                        )
                     current_phrase = ""
 
                     tokenizer.skip_white_space()
-                    section = "SECTION_WHERE"
+                    if tokenizer.current() == ",":
+                        tokenizer.next_until([","])
+                        # Another attr to update
+                        pass
+                    else:
+                        section = "SECTION_WHERE"
                 elif section == "WHERE":
                     attr_name = current_phrase
                     tokenizer.skip_white_space()
-                    quote_type = tokenizer.current()
-                    assert quote_type in ["'", '"']
+                    if tokenizer.current() == "?":
+                        attr_filters.append((current_phrase, "?"))
+                        tokenizer.next_until(["?"])
+                    else:
+                        quote_type = tokenizer.current()
+                        assert quote_type in ["'", '"']
 
-                    tokenizer.next()
-                    attr_value = tokenizer.next_until([quote_type])
-                    attr_filters.append((attr_name, serializer.serialize(attr_value)))
+                        tokenizer.next()
+                        attr_value = tokenizer.next_until([quote_type])
+                        attr_filters.append(
+                            (attr_name, serializer.serialize(attr_value))
+                        )
 
                     tokenizer.skip_white_space()
                     current_phrase = ""

--- a/py_partiql_parser/_internal/utils.py
+++ b/py_partiql_parser/_internal/utils.py
@@ -133,9 +133,11 @@ class QueryMetadata:
         self,
         tables: Dict[str, str],
         where_clause: Optional["AbstractWhereClause"] = None,
+        is_select_query: bool = False,
     ):
         self._tables = tables
         self._where_clause = where_clause
+        self._is_select_query = is_select_query
 
     def get_table_names(self) -> List[str]:
         return list(self._tables.values())
@@ -144,6 +146,9 @@ class QueryMetadata:
         if self._where_clause:
             return self._where_clause.get_filter_names()
         return []
+
+    def is_select_query(self) -> bool:
+        return self._is_select_query
 
 
 class Variable:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "py-partiql-parser"
-version = "0.5.0"
+version = "0.5.1"
 description = "Pure Python PartiQL Parser"
 readme = "README.md"
 keywords = ["pypartiql", "parser"]

--- a/tests/test_query_metadata.py
+++ b/tests/test_query_metadata.py
@@ -41,3 +41,27 @@ def test_nested_filter_names() -> None:
     metadata = DynamoDBStatementParser.get_query_metadata(query)
 
     assert metadata.get_filter_names() == ["k1", "k2.sth"]
+
+
+def test_update_statement() -> None:
+    query = 'UPDATE users SET "first_name" = ?, "last_name" = ? WHERE "username"= ?'
+    metadata = DynamoDBStatementParser.get_query_metadata(query)
+
+    assert metadata.get_table_names() == ["users"]
+    assert metadata.get_filter_names() == []
+
+
+def test_insert_statement() -> None:
+    query = "INSERT INTO 'mytable' value {'id': 'id1'}"
+    metadata = DynamoDBStatementParser.get_query_metadata(query)
+
+    assert metadata.get_table_names() == ["mytable"]
+    assert metadata.get_filter_names() == []
+
+
+def test_delete_statement() -> None:
+    query = "DELETE FROM 'tablename' WHERE Id='id1'"
+    metadata = DynamoDBStatementParser.get_query_metadata(query)
+
+    assert metadata.get_table_names() == ["tablename"]
+    assert metadata.get_filter_names() == []


### PR DESCRIPTION
Support INSERT/DELETE/UPDATE queries:
 - that contain a table name without quotes
 - that contain parameters
 - when calling `get_query_metadata`

We also now throw an error if the number of supplied parameters does not match the number of expected parameters