### PR TITLE
S3: API now also returns number of bytes processed

### DIFF
--- a/py_partiql_parser/_internal/clause_tokenizer.py
+++ b/py_partiql_parser/_internal/clause_tokenizer.py
@@ -5,6 +5,12 @@ class ClauseTokenizer:
     def __init__(self, from_clause: str):
         self.token_list = from_clause
         self.token_pos = 0
+        self.tokens_parsed = 0
+
+    def get_tokens_parsed(self) -> int:
+        x = self.tokens_parsed
+        self.tokens_parsed = 0
+        return x
 
     def current(self) -> Optional[str]:
         """
@@ -22,6 +28,7 @@ class ClauseTokenizer:
         """
         try:
             crnt_token = self.token_list[self.token_pos]
+            self.tokens_parsed += 1
             self.token_pos += 1
             return crnt_token
         except IndexError:
@@ -34,11 +41,13 @@ class ClauseTokenizer:
             return None
 
     def revert(self) -> None:
+        self.tokens_parsed -= 1
         self.token_pos -= 1
 
     def skip_white_space(self) -> None:
         try:
             while self.token_list[self.token_pos] in [" ", "\n"]:
+                self.tokens_parsed += 1
                 self.token_pos += 1
         except IndexError:
             pass

--- a/py_partiql_parser/_internal/json_parser.py
+++ b/py_partiql_parser/_internal/json_parser.py
@@ -1,5 +1,5 @@
 from json import JSONEncoder
-from typing import Any, List, Iterator, Optional
+from typing import Any, List, Iterator, Optional, Tuple
 
 from .clause_tokenizer import ClauseTokenizer
 from .utils import CaseInsensitiveDict, Variable
@@ -24,6 +24,17 @@ class JsonParser:
             result = JsonParser._get_next_document(original, tokenizer)
             if result is not None:
                 yield result
+
+    @staticmethod
+    def parse_with_tokens(original: str) -> Iterator[Tuple[Any, int]]:  # type: ignore[misc]
+        """
+        Parse JSON string. Returns a tuple of (json_doc, nr_of_bytes_processed)
+        """
+        tokenizer = ClauseTokenizer(original)
+        while tokenizer.current() is not None:
+            result = JsonParser._get_next_document(original, tokenizer)
+            if result is not None:
+                yield result, tokenizer.get_tokens_parsed()
 
     @staticmethod
     def _get_next_document(  # type: ignore[misc]

--- a/tests/test_json_encoder.py
+++ b/tests/test_json_encoder.py
@@ -13,12 +13,12 @@ def test_json_output_can_be_dumped() -> None:
             "kids": None,
         }
     )
-    result = S3SelectParser(source_data={"s3object": input_with_none}).parse(query)
+    result = S3SelectParser(source_data=input_with_none).parse(query)
     assert f"[{input_with_none}]" == json.dumps(result, cls=SelectEncoder)
 
 
 def test_json_with_lists_can_be_dumped() -> None:
     query = "select * from s3object s"
     input_with_none = json.dumps(input_with_lists[0])
-    result = S3SelectParser(source_data={"s3object": input_with_none}).parse(query)
+    result = S3SelectParser(source_data=input_with_none).parse(query)
     assert f"[{input_with_none}]" == json.dumps(result, cls=SelectEncoder)

--- a/tests/test_s3_examples.py
+++ b/tests/test_s3_examples.py
@@ -22,7 +22,7 @@ input_json_object = {"a1": "b1", "a2": "b2"}
 @pytest.mark.xfail(reason="CSV functionality not yet implemented")
 def test_aws_sample__csv() -> None:
     query = "SELECT * FROM s3object s where s.\"Name\" = 'Jane'"
-    x = S3SelectParser(source_data={"s3object": input_data_csv}).parse(query)
+    x = S3SelectParser(source_data=input_data_csv).parse(query)
 
 
 @pytest.mark.xfail(
@@ -30,7 +30,7 @@ def test_aws_sample__csv() -> None:
 )
 def test_aws_sample__json__search_by_name() -> None:
     query = "SELECT * FROM s3object s where s.\"Name\" = 'Jane'"
-    result = S3SelectParser(source_data={"s3object": input_json_list}).parse(query)  # type: ignore
+    result = S3SelectParser(source_data=input_json_list).parse(query)  # type: ignore
     assert result == [
         {
             "Name": "Jane",
@@ -49,7 +49,7 @@ def test_aws_sample__json__search_by_name() -> None:
     ],
 )
 def test_aws_sample__json__search_by_city(query: str) -> None:
-    result = S3SelectParser(source_data={"s3object": json_as_lines}).parse(query)
+    result = S3SelectParser(source_data=json_as_lines).parse(query)
     assert len(result) == 4
     assert {
         "Name": "Jane",
@@ -79,7 +79,7 @@ def test_aws_sample__json__search_by_city(query: str) -> None:
 
 def test_aws_sample__json_select_multiple_attrs__search_by_city() -> None:
     query = "SELECT s.name, s.city FROM s3object s where s.\"City\" = 'Chicago'"
-    result = S3SelectParser(source_data={"s3object": json_as_lines}).parse(query)
+    result = S3SelectParser(source_data=json_as_lines).parse(query)
     assert len(result) == 4
     assert {
         "Name": "Jane",
@@ -101,33 +101,25 @@ def test_aws_sample__json_select_multiple_attrs__search_by_city() -> None:
 
 def test_aws_sample__object_select_all() -> None:
     query = "SELECT * FROM s3object"
-    result = S3SelectParser(
-        source_data={"s3object": json.dumps(input_json_object)}
-    ).parse(query)
+    result = S3SelectParser(source_data=json.dumps(input_json_object)).parse(query)
     assert result == [input_json_object]
 
 
 def test_aws_sample__s3object_is_case_insensitive() -> None:
     query = "SELECT * FROM s3obJEct"
-    result = S3SelectParser(
-        source_data={"s3object": json.dumps(input_json_object)}
-    ).parse(query)
+    result = S3SelectParser(source_data=json.dumps(input_json_object)).parse(query)
     assert result == [input_json_object]
 
 
 def test_aws_sample__object_select_everything() -> None:
     query = "SELECT s FROM s3object AS s"
-    result = S3SelectParser(
-        source_data={"s3object": json.dumps(input_json_object)}
-    ).parse(query)
+    result = S3SelectParser(source_data=json.dumps(input_json_object)).parse(query)
     assert result == [input_json_object]
 
 
 def test_aws_sample__object_select_attr() -> None:
     query = "SELECT s.a1 FROM s3object AS s"
-    result = S3SelectParser(
-        source_data={"s3object": json.dumps(input_json_object)}
-    ).parse(query)
+    result = S3SelectParser(source_data=json.dumps(input_json_object)).parse(query)
     assert result == [{"a1": "b1"}]
 
 
@@ -140,13 +132,13 @@ def test_case_insensitivity() -> None:
         + "\n"
         + json.dumps({"Name": "Vinod", "City": "Los Angeles"})
     )
-    parser = S3SelectParser(source_data={"s3object": all_rows})
+    parser = S3SelectParser(source_data=all_rows)
     assert parser.parse(query) == [{"Name": "Vinod", "City": "Los Angeles"}]
 
 
 def test_select_doc_using_asterisk() -> None:
     query = "select * from s3object[*]"
-    result = S3SelectParser(source_data={"s3object": json_as_lines}).parse(query)
+    result = S3SelectParser(source_data=json_as_lines).parse(query)
     assert len(result) == 7
     assert {
         "Name": "Sam",
@@ -164,7 +156,7 @@ def test_select_doc_using_asterisk() -> None:
     ],
 )
 def test_select_specific_object_doc_using_named_asterisk(query: str) -> None:
-    result = S3SelectParser(source_data={"s3object": json_as_lines}).parse(query)
+    result = S3SelectParser(source_data=json_as_lines).parse(query)
     assert len(result) == 7
     assert {"my_n": "Sam"} in result
     assert {"my_n": "Jeff"} in result
@@ -175,7 +167,7 @@ def test_select_specific_object_doc_using_named_asterisk(query: str) -> None:
     ["select * from s3object[*].Name my_n", "select * from s3object[*].Name as my_n"],
 )
 def test_select_nested_object_using_named_asterisk(query: str) -> None:
-    result = S3SelectParser(source_data={"s3object": json_as_lines}).parse(query)
+    result = S3SelectParser(source_data=json_as_lines).parse(query)
     assert len(result) == 7
     assert {"_1": "Sam"} in result
     assert {"_1": "Jeff"} in result
@@ -183,9 +175,7 @@ def test_select_nested_object_using_named_asterisk(query: str) -> None:
 
 def test_select_list_using_asterisk() -> None:
     query = "select * from s3object[*] s"
-    result = S3SelectParser(
-        source_data={"s3object": json.dumps(input_with_lists)}
-    ).parse(query)
+    result = S3SelectParser(source_data=json.dumps(input_with_lists)).parse(query)
     assert result == [{"_1": input_with_lists}]
 
 
@@ -194,7 +184,23 @@ def test_select_list_using_asterisk() -> None:
     ["select * from s3object[*].staff s", "select * from s3object[*].staff[*] s"],
 )
 def test_select_nested_list_using_asterisk(query: str) -> None:
-    result = S3SelectParser(
-        source_data={"s3object": json.dumps(input_with_lists)}
-    ).parse(query)
+    result = S3SelectParser(source_data=json.dumps(input_with_lists)).parse(query)
     assert result == [{}]
+
+
+def test_nested_where_clause() -> None:
+    query = "select * from s3object[*] s where s.c = 'd2'"
+    doc = "".join(
+        [json.dumps(x) for x in [{"a": {f"b{i}": "s"}, "c": f"d{i}"} for i in range(5)]]
+    )
+    result = S3SelectParser(source_data=doc).parse(query)
+    assert result == [{"a": {"b2": "s"}, "c": "d2"}]
+
+
+def test_nested_from_clause() -> None:
+    query = "select * from s3object[*].a"
+    doc = "".join(
+        [json.dumps(x) for x in [{"a": {f"b{i}": "s"}, "c": f"d{i}"} for i in range(5)]]
+    )
+    result = S3SelectParser(source_data=doc).parse(query)
+    assert {"b2": "s"} in result

--- a/tests/test_select_functions.py
+++ b/tests/test_select_functions.py
@@ -5,7 +5,7 @@ from . import json_as_lines
 
 class TestCount:
     def setup_method(self) -> None:
-        self.parser = S3SelectParser(source_data={"s3object": json_as_lines})
+        self.parser = S3SelectParser(source_data=json_as_lines)
 
     @pytest.mark.parametrize(
         "query,key,result",

--- a/tests/test_select_parser.py
+++ b/tests/test_select_parser.py
@@ -4,35 +4,33 @@ from py_partiql_parser._internal.select_parser import SelectClause, FunctionClau
 
 
 def test_select_all_clause() -> None:
-    result = SelectParser(table_prefix=None).parse_clauses("*")
+    result = SelectParser().parse_clauses("*")
     assert result == [SelectClause("*")]
 
 
 def test_parse_simple_clause() -> None:
-    result = SelectParser(table_prefix=None).parse_clauses("s.name")
+    result = SelectParser().parse_clauses("s.name")
     assert result == [SelectClause("s.name")]
 
 
 def test_parse_multiple_clauses() -> None:
-    result = SelectParser(table_prefix=None).parse_clauses("s.name, s.city")
+    result = SelectParser().parse_clauses("s.name, s.city")
     assert result == [SelectClause("s.name"), SelectClause("s.city")]
 
 
 def test_parse_function_clause() -> None:
-    result = SelectParser(table_prefix=None).parse_clauses("count(*)")
+    result = SelectParser().parse_clauses("count(*)")
     assert result == [FunctionClause(function_name="count", value="*")]
 
 
 @pytest.mark.xfail(reason="Not yet implemented")
 def test_parse_function_alias_clause() -> None:
-    result = SelectParser(table_prefix=None).parse_clauses("count(*) as cnt")
+    result = SelectParser().parse_clauses("count(*) as cnt")
     assert result == [FunctionClause(function_name="count", value="*")]
 
 
 def test_parse_mix_of_function_and_regular_clauses() -> None:
-    result = SelectParser(table_prefix=None).parse_clauses(
-        "count(*), s.city, max(s.citizens)"
-    )
+    result = SelectParser().parse_clauses("count(*), s.city, max(s.citizens)")
     assert len(result) == 3
     assert FunctionClause(function_name="count", value="*") in result
     assert FunctionClause(function_name="max", value="s.citizens") in result

--- a/tests/test_where_parser.py
+++ b/tests/test_where_parser.py
@@ -168,14 +168,48 @@ class TestFilter:
     ]
 
     def test_simple(self) -> None:
-        assert S3WhereParser(TestFilter.all_rows).parse(  # type: ignore[arg-type]
-            _where_clause="city = 'Los Angeles'"
-        ) == [{"Name": "Vinod", "city": "Los Angeles"}]
+        query = "s3.city = 'Los Angeles'"
+        assert not S3WhereParser.applies(
+            doc={"Name": "Sam", "city": "Irvine"},
+            table_prefix="s3",
+            _where_clause=query,
+        )
+        assert not S3WhereParser.applies(
+            doc={"Name": "Sam", "city": "Seattle"},
+            table_prefix="s3",
+            _where_clause=query,
+        )
+        assert not S3WhereParser.applies(
+            doc={"Name": "Sam", "city": "Chicago"},
+            table_prefix="s3",
+            _where_clause=query,
+        )
+        assert not S3WhereParser.applies(
+            doc={"Name": "Sam"}, table_prefix="s3", _where_clause=query
+        )
+
+        assert S3WhereParser.applies(
+            doc={"Name": "Sam", "city": "Los Angeles"},
+            table_prefix="s3",
+            _where_clause=query,
+        )
 
     def test_alias_nested_key(self) -> None:
-        assert S3WhereParser(TestFilter.all_rows).parse(  # type: ignore[arg-type]
-            _where_clause="notes.extra = 'y'"
-        ) == [{"Name": "Mary", "city": "Chicago", "notes": {"extra": "y"}}]
+        query = "s3.notes.extra = 'y'"
+        assert not S3WhereParser.applies(
+            doc={"Name": "Sam", "city": "Chicago"},
+            table_prefix="s3",
+            _where_clause=query,
+        )
+        assert not S3WhereParser.applies(
+            doc={"Name": "Sam"}, table_prefix="s3", _where_clause=query
+        )
+
+        assert S3WhereParser.applies(
+            doc={"Name": "Sam", "notes": {"extra": "y"}},
+            table_prefix="s3",
+            _where_clause=query,
+        )
 
 
 class TestDynamoDBParse:


### PR DESCRIPTION
Also simplifies the flow. The input is now processed one document at a time:
```
for document in source:
    # process FROM clause
    # check if WHERE clause is applicable
    # process SELECT clause
    add document
```
Which should make it much easier to add support for a LIMIT-clause later on.

Note that only the S3-part has been changed, the DynamoDB part is unchanged.