### PR TITLE
Fix 'ValueError: invalid literal for int() with base 10' when parsing a float in JSON data

### DIFF
--- a/py_partiql_parser/_internal/json_parser.py
+++ b/py_partiql_parser/_internal/json_parser.py
@@ -180,6 +180,9 @@ class JsonParser:
                 current_phrase = ""
                 section = None
                 tokenizer.skip_white_space()
+            elif c == "." and section == "INT_VALUE":
+                section = "VAR_VALUE"
+                current_phrase += c
             elif c == "," and not section:
                 tokenizer.skip_white_space()
             elif not section:


### PR DESCRIPTION
I was running into this error when using moto and S3 select queries to retrieve float values from nested JSON data stored in a moto S3 bucket. This change resolved the issue for me.